### PR TITLE
FEAT: Added two functions in src/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate regex;
 
-use std::process::Command;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use regex::Regex;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::process::Command;
 
 pub fn get() -> Option<IpAddr> {
     let output = Command::new("ifconfig")
@@ -16,10 +16,10 @@ pub fn get() -> Option<IpAddr> {
         if let Some(host) = cap.at(2) {
             if host != "127.0.0.1" {
                 if let Ok(addr) = host.parse::<Ipv4Addr>() {
-                    return Some(IpAddr::V4(addr))
+                    return Some(IpAddr::V4(addr));
                 }
                 if let Ok(addr) = host.parse::<Ipv6Addr>() {
-                    return Some(IpAddr::V6(addr))
+                    return Some(IpAddr::V6(addr));
                 }
             }
         }
@@ -28,9 +28,55 @@ pub fn get() -> Option<IpAddr> {
     None
 }
 
+pub fn get_iface_addr(iface: &str) -> Option<IpAddr> {
+    let output = Command::new("ifconfig")
+        .arg(iface)
+        .output()
+        .expect("failed to execute `ifconfig`");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    let re = Regex::new(r#"(?m)^.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*$"#).unwrap();
+    for cap in re.captures_iter(&stdout) {
+        if let Some(host) = cap.at(2) {
+            if host != "127.0.0.1" {
+                if let Ok(addr) = host.parse::<Ipv4Addr>() {
+                    return Some(IpAddr::V4(addr));
+                }
+                if let Ok(addr) = host.parse::<Ipv6Addr>() {
+                    return Some(IpAddr::V6(addr));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+pub fn get_ifaces() -> Vec<String> {
+    let output = Command::new(format!("ls"))
+        .arg("/sys/class/net")
+        .output()
+        .expect("failed to execute `ifconfig`");
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+
+    //let re = Regex::new(r#"(?m)^?(([a-z][0-9]).*).*$"#).unwrap();
+    let re = Regex::new(r#".*"#).unwrap();
+    let mut ifaces = vec!["".to_string(); 0];
+    for cap in re.captures_iter(&stdout) {
+        if let Some(host) = cap.at(0) {
+            if cap.at(0).unwrap() != "" {
+                ifaces.push(host.to_string());
+            }
+        }
+    }
+
+    ifaces
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-    }
+    fn it_works() {}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
-#![feature(alloc_system)]
-extern crate alloc_system;
-
 extern crate local_ip;
 
 fn main() {
-    println!("{}", local_ip::get().expect("Could not find local IP address.").to_string());
+    println!(
+        "{}",
+        local_ip::get()
+            .expect("Could not find local IP address.")
+            .to_string()
+    );
 }


### PR DESCRIPTION
I was looking or a quick and simple way to get Configured IP addresses
to be able to make a SocketAddr to bind a TcpListener and found this
crate was useful but I was missing a way to specify the network
interface and a way to check user provided interface names against the
list of all network interfaces on the system to be able to perform some
error handling if the user misspell the interface name or give a wrong
one.

* First function : pub fn get_ifaces() -> Vec<String>

This function takes no arguments and returns a Vec of all networks
interfaces using `ls /sys/class/net` to stay in the philosophy of the
crate.

* Second function pub fn get_iface_addr(iface: &str) -> Option<IpAddr>

This function takes a &str of the name of a network interface name  and
returns the IpAddr of the IP address of that interface.